### PR TITLE
Copy _redirects file to output path before publish, and make sure to use environmental variable for key, and fixed runtime error when click can't find a click context

### DIFF
--- a/lektor_netlify.py
+++ b/lektor_netlify.py
@@ -11,7 +11,8 @@ from werkzeug import urls
 
 class NetlifyPublisher(Publisher):
     def publish(self, target_url, credentials=None, server_info=None, **extra):
-        draft = '--draft' in click.get_current_context().args
+        click_context = click.get_current_context(True)
+        draft = '--draft' in click_context.args if click_context else None
         host = target_url.host
 
         if credentials and credentials.get('key'):

--- a/lektor_netlify.py
+++ b/lektor_netlify.py
@@ -26,7 +26,7 @@ class NetlifyPublisher(Publisher):
                 " see https://github.com/ajdavis/lektor-netlify/README.md")
         
         redirects_content = os.path.join(self.env.root_path, 'content', '_redirects')
-        redirects_build = os.path.join(self.env.root_path, 'build', '_redirects')
+        redirects_build = os.path.join(self.output_path, '_redirects')
         if os.path.isfile(redirects_content):
             shutil.copy2(redirects_content, redirects_build)
 

--- a/lektor_netlify.py
+++ b/lektor_netlify.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import click
+import os
 import requests
 from lektor.pluginsystem import Plugin
 from lektor.publisher import Publisher, Command
@@ -16,6 +17,8 @@ class NetlifyPublisher(Publisher):
             access_token = credentials['key']
         elif server_info and server_info.extra.get('key'):
             access_token = server_info.extra['key']
+        elif os.environ.get('LEKTOR_DEPLOY_KEY'):
+            access_token = os.environ.get('LEKTOR_DEPLOY_KEY')
         else:
             raise RuntimeError(
                 "Use lektor deploy --key <ACCESS_TOKEN>,"

--- a/lektor_netlify.py
+++ b/lektor_netlify.py
@@ -2,6 +2,7 @@
 import click
 import os
 import requests
+import shutil
 from lektor.pluginsystem import Plugin
 from lektor.publisher import Publisher, Command
 from lektor.utils import slugify, bool_from_string
@@ -23,6 +24,11 @@ class NetlifyPublisher(Publisher):
             raise RuntimeError(
                 "Use lektor deploy --key <ACCESS_TOKEN>,"
                 " see https://github.com/ajdavis/lektor-netlify/README.md")
+        
+        redirects_content = os.path.join(self.env.root_path, 'content', '_redirects')
+        redirects_build = os.path.join(self.env.root_path, 'build', '_redirects')
+        if os.path.isfile(redirects_content):
+            shutil.copy2(redirects_content, redirects_build)
 
         sites_url = (
             'https://api.netlify.com/api/v1/sites?access_token=' +


### PR DESCRIPTION
Before these changes:
- the `_redirects` file wouldn't get copied to the build folder and deployed
- deploying via the web interface would fail, despite setting both the environmental variable AND the key in the `<projectname>.lektorproject` file
- deploying via the web interface would also fail because click can't find the click context
