### PR TITLE
Adds python3 support

### DIFF
--- a/lektor_netlify.py
+++ b/lektor_netlify.py
@@ -31,6 +31,12 @@ class NetlifyPublisher(Publisher):
 
         response.raise_for_status()
         j = response.json()
+        
+        try:
+            unicode        # check if unicode is defined
+        except NameError:  # not found: python 3: replace by str
+            unicode = str
+        
         for site in j:
             site_url = urls.url_parse(unicode(site['url']))
             if site_url.host == host:


### PR DESCRIPTION
## Context
Python 3.12 deprecated the `unicode` method in favor of `str`. As a result, systems running Python >= 3.12 throw `NameError: name 'unicode' is not defined` when running this plugin.

## Fix
This PR adds some code to detected whether the `unicode` method is available. If it isn't, it substitutes `str`, which enables the rest of the code to work as-is.

Note that although I've tested this on a system with Python >= 3.12 (I'm running `3.9.12`), I haven't confirmed that it still works with systems running Python 2, although I can't imagine why it wouldn't.